### PR TITLE
Fix ssh key was already added check

### DIFF
--- a/git-idm
+++ b/git-idm
@@ -161,7 +161,7 @@ function identity_exists() {
 }
 
 function check_ssh_agent() {
-    if ! ssh-add -l | grep -F -- "$1" &> /dev/null; then
+    if ! ssh-add -l | grep -F "$(ssh-keygen -lf $1)" -- &> /dev/null; then
         echo "WARNING: $1 has not been added to ssh-agent.  To fix run: ssh-add '$1'" >&2
     fi
 }


### PR DESCRIPTION
The function "check_ssh_agent" fail to check a key when its already added by 'ssh-add'. The command "ssh-add -l" return a finger print of installed keys. Then "grep" should be used to search for the key's finger print and not the key's file name.