### PR TITLE
Corrected typo, added signing example

### DIFF
--- a/git-idm
+++ b/git-idm
@@ -3,7 +3,7 @@
 #License: MIT
 #Project URL: https://github.com/samrocketman/git-identity-manager
 
-version='0.7'
+version='0.8'
 
 if ! git --version | awk 'BEGIN { FS="." }; $2 < 13 { exit(1) }'; then
     echo 'WARNING: "git --version" is older than Git 2.13.  git-idm will have unexpected behavior.' >&2
@@ -64,6 +64,10 @@ Example usage:
       git ${cmd} list
       git ${cmd} use jcool
       git ${cmd} remove jcool
+	  
+	Adding with a GPG key and signing each commit
+	
+	  git ${cmd} add jcool --name "Joe Cool" --email "joe@example.com" --key ~/.ssh/id_rsa --signing-key 1AA11AAA111A1AAA --sign-commits
 
     Auto-switching identities based on a tracked directory path of cloned
     repositories.
@@ -101,7 +105,7 @@ Command options:
                     --email EMAIL - Email of the associated identity.
                     --key SSH_KEY - SSH private key of the associated identity.
                     --signing-key SIGNING_KEY - (optional) add a gpg signing key.
-                    --sign-comits SIGN_COMMITS (optional) whether or not to sign commits.
+                    --sign-commits SIGN_COMMITS (optional) whether or not to sign commits.
         --ssh-command SSH_COMMAND - Customize the SSH command ignoring --key.
     list:
         Has no options.


### PR DESCRIPTION
Corrected a typo, the parameter is --sign-commits and not --sign-comits
Added an example that includes GPG and signing